### PR TITLE
Adding customizable dice number for skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ For example, Crash's autohide rolls work after a few adjustments (I can share my
 - Vehicles
 - Ships
 - Compendiums (if anyone wants to make and export these themselves, I'll add them to the repo)
-- Ammo/resource consumption for attacks specifically, without activated abilities
 
 # Impending Improvements
 - Automate the 'other' ability modifier (will require making a shown vs final attribute)

--- a/lang/en.json
+++ b/lang/en.json
@@ -223,6 +223,7 @@
 "SWNPRETTY.DefaultAbilityCheck": "Default Ability Check",
 "SWNPRETTY.Description": "Description",
 "SWNPRETTY.Details": "Details",
+"SWNPRETTY.DiceNumTitle": "# Dice Per Skill",
 "SWNPRETTY.Dimensions": "Dimensions",
 "SWNPRETTY.Disadvantage": "Disadvantage",
 "SWNPRETTY.DistAny": "Any",

--- a/module/actor/entity.js
+++ b/module/actor/entity.js
@@ -932,6 +932,8 @@ export default class Actor5e extends Actor {
     const parts = ["@mod"];
     const data = {mod: skl.value + skl.prof + attr};
 
+    console.log("dice num is ",skl.diceNum.concat("d6"));
+
     // Ability test bonus
     if ( bonuses.check ) {
       data["checkBonus"] = bonuses.check;
@@ -958,7 +960,8 @@ export default class Actor5e extends Actor {
       data: data,
       title: game.i18n.format("SWNPRETTY.SkillPromptTitle", {skill: CONFIG.SWNPRETTY.skills[skillId]}),
       fastForward: true,
-      die: "2d6",
+      die: skl.diceNum.concat("d6"),
+      // die: "2d6",
       formula:`2d6${skl.value}`,
       critical: 6,
       // messageData: {"flags.swnpretty.roll": {type: "skill", skillId }}

--- a/module/apps/actor-flags.js
+++ b/module/apps/actor-flags.js
@@ -107,11 +107,11 @@ export default class ActorSheetFlags extends DocumentSheet {
 
     // Unset any flags which are "false"
     let unset = false;
-    const flags = updateData.flags.SWNPRETTY;
+    const flags = updateData.flags.swnpretty;
     for ( let [k, v] of Object.entries(flags) ) {
       if ( [undefined, null, "", false, 0].includes(v) ) {
         delete flags[k];
-        if ( hasProperty(actor.data._source.flags, `SWNPRETTY.${k}`) ) {
+        if ( hasProperty(actor.data._source.flags, `swnpretty.${k}`) ) {
           unset = true;
           flags[`-=${k}`] = null;
         }

--- a/module/config.js
+++ b/module/config.js
@@ -38,7 +38,7 @@ SWNPRETTY.abilityAbbreviations = {
 
 SWNPRETTY.attackSkills = {
   "pun": "SWNPRETTY.SkillPun",
-  "sht": "SWNPRETTY.SkillSht",
+  "sho": "SWNPRETTY.SkillSho",
   "stb": "SWNPRETTY.SkillStb"
 };
 

--- a/module/dice.js
+++ b/module/dice.js
@@ -116,10 +116,18 @@ export async function d20Roll({
   }={}) {
 
   //I'm updating this to use non-d20s, edit as necessary. -Lofty
-  // console.log("this is the formula (die)",die);
-  if(die !== "2d6"){
-    die = "1d20";
+  // console.log("die length is ", die.length);
+  console.log("die is",die)
+  // Checks the last digit is a 6. So if it's a 6 sided ie, it will do a d6 roll, otherwise a d20 roll -Lofty
+  //This first if makes sure it's not undefined, like for attack rolls
+  if(die){
+    if(die[(die.length)-1] !== "6"){
+      die = "1d20";
+    }
   }
+  else{
+      die = "1d20";
+    }
   // Handle input arguments
   const formula = [die].concat(parts).join(" + ");
   // let formula = `${nd}d20${mods}`;

--- a/template.json
+++ b/template.json
@@ -161,79 +161,98 @@
         "skills": {
           "adm": {
             "value": -1,
-            "ability": "str"
+            "ability": "str",
+            "diceNum": "2"
           },
           "con": {
             "value": -1,
-            "ability": "str"
+            "ability": "str",
+            "diceNum": "2"
           },
           "exe": {
             "value": -1,
-            "ability": "str"
+            "ability": "str",
+            "diceNum": "2"
           },
           "fix": {
             "value": -1,
-            "ability": "str"
+            "ability": "str",
+            "diceNum": "2"
           },
           "hea": {
             "value": -1,
-            "ability": "str"
+            "ability": "str",
+            "diceNum": "2"
           },
           "kno": {
             "value": -1,
-            "ability": "str"
+            "ability": "str",
+            "diceNum": "2"
           },
           "lea": {
             "value": -1,
-            "ability": "str"
+            "ability": "str",
+            "diceNum": "2"
           },
           "per": {
             "value": -1,
-            "ability": "str"
+            "ability": "str",
+            "diceNum": "2"
           },
           "not": {
             "value": -1,
-            "ability": "str"
+            "ability": "str",
+            "diceNum": "2"
           },
           "pil": {
             "value": -1,
-            "ability": "str"
+            "ability": "str",
+            "diceNum": "2"
           },
           "pro": {
             "value": -1,
-            "ability": "str"
+            "ability": "str",
+            "diceNum": "2"
           },
           "sho": {
             "value": -1,
-            "ability": "str"
+            "ability": "str",
+            "diceNum": "2"
           },
           "sne": {
             "value": -1,
-            "ability": "str"
+            "ability": "str",
+            "diceNum": "2"
           },
           "pun": {
             "value": -1,
-            "ability": "str"
+            "ability": "str",
+            "diceNum": "2"
           },
           "stb": {
             "value": -1,
-            "ability": "str"
+            "ability": "str",
+            "diceNum": "2"
           },
           "sur": {
             "value": -1,
-            "ability": "str"
+            "ability": "str",
+            "diceNum": "2"
           },
           "tal": {
             "value": -1,
-            "ability": "str"
+            "ability": "str",
+            "diceNum": "2"
           },
           "trd": {
             "value": -1,
-            "ability": "str"
+            "ability": "str",
+            "diceNum": "2"
           },
           "wor": {
             "value": -1,
-            "ability": "str"
+            "ability": "str",
+            "diceNum": "2"
           },
           "pre": {
             "value": -1,

--- a/templates/apps/actor-flags.html
+++ b/templates/apps/actor-flags.html
@@ -2,33 +2,6 @@
     <section class="form-body">
 <!--	    <p class="notes">{{localize 'SWNPRETTY.FlagsInstructions'}}</p>-->
 
-        {{#each flags as |fs section|}}
-        <h3 class="form-header">{{localize section}}</h3>
-        {{#each fs as |flag key|}}
-
-        <div class="form-group">
-            <label>{{localize flag.name}}</label>
-
-            {{#if flag.isCheckbox}}
-            <input type="checkbox" name="{{key}}" data-dtype="Boolean" {{checked flag.value}}/>
-
-            {{else if flag.isSelect}}
-            <select name="{{key}}" data-dtype="{{flag.type}}">
-                {{#select flag.value}}
-                {{#each flag.choices as |v k|}}
-                <option value="{{k}}">{{localize v}}</option>
-                {{/each}}
-                {{/select}}
-            </select>
-
-            {{else}}
-            <input type="text" name="{{key}}" value="{{flag.value}}" placeholder="{{flag.placeholder}}" data-dtype="{{flag.type}}"/>
-            {{/if}}
-
-            <p class="notes">{{localize flag.hint}}</p>
-        </div>
-        {{/each}}
-        {{/each}}
 
         <h3 class="form-header">{{localize "SWNPRETTY.Bonuses"}}</h3>
         <p class="notes">{{localize "SWNPRETTY.BonusesHint"}}</p>
@@ -37,6 +10,17 @@
             <label>{{localize b.label}}</label>
             <input type="text" name="{{b.name}}" value="{{b.value}}"/>
         </div>
+        {{/each}}
+
+        <h3 class="form-header">{{localize "SWNPRETTY.DiceNumTitle"}}</h3>
+        {{#each data.skills as |skill s|}}
+            <li class="skill flexrow" data-skill="{{s}}">
+                <div class="form-group">
+<!--                    <label>{{localize s.label}}</label>-->
+                    <h4 class="skill-name rollable">{{skill.label}}</h4>
+                    <input type="text" name="data.skills.{{s}}.diceNum" value="{{s.diceNum}}" data-dtype="Number"/>
+                </div>
+            </li>
         {{/each}}
     </section>
 


### PR DESCRIPTION
There's a bug stopping updating of the global variables still (I checked and it's been here since I reintroduced them in 2.2 I think). The skills aren't showing up yet, but the backend should be set up for it.